### PR TITLE
Refine desktop hero typography

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,16 +95,20 @@ nav a[aria-current="page"] {
 
 .hero {
     display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+    grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
     gap: clamp(28px, 5vw, 72px);
     align-items: center;
     min-height: calc(100vh - 82px);
-    padding: 76px 0 88px;
+    padding: 68px 0 80px;
 }
 
 .hero-copy,
 .page-hero {
     max-width: 820px;
+}
+
+.hero-copy {
+    max-width: 760px;
 }
 
 .eyebrow {
@@ -127,12 +131,12 @@ h1,
 h2,
 h3 {
     margin: 0;
-    line-height: 1.05;
+    line-height: 1.08;
 }
 
 h1 {
-    max-width: 900px;
-    font-size: clamp(2.6rem, 7vw, 5.8rem);
+    max-width: 820px;
+    font-size: clamp(2.6rem, 4.8vw, 4.45rem);
     letter-spacing: 0;
 }
 
@@ -146,10 +150,10 @@ h3 {
 }
 
 .lead {
-    max-width: 720px;
+    max-width: 700px;
     margin: 24px 0 0;
     color: var(--muted);
-    font-size: clamp(1.05rem, 2vw, 1.3rem);
+    font-size: clamp(1.05rem, 1.7vw, 1.22rem);
     line-height: 1.65;
 }
 


### PR DESCRIPTION
## Summary
- Reduces the desktop homepage hero heading size so it does not dominate wide screens
- Narrows the hero text column and adjusts the lead paragraph scale
- Keeps the existing mobile styling intact

## Notes
- This PR is based on the current `main` branch, which already contains the modernized site content.